### PR TITLE
Upgrade CXF version to 3.4.x

### DIFF
--- a/frameworks/cxf/pom.xml
+++ b/frameworks/cxf/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<osgi.version>5.0.0</osgi.version>
-		<cxf.version>3.3.3</cxf.version>
+		<cxf.version>3.4.3</cxf.version>
 		<jaxb.version>2.3.1</jaxb.version>
 	</properties>
 

--- a/frameworks/cxf/src/main/java/com/github/skjolber/xmlfilter/cxf/LoggingInInterceptor.java
+++ b/frameworks/cxf/src/main/java/com/github/skjolber/xmlfilter/cxf/LoggingInInterceptor.java
@@ -20,6 +20,7 @@ package com.github.skjolber.xmlfilter.cxf;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.common.util.StringUtils;
@@ -50,7 +51,7 @@ public class LoggingInInterceptor extends AbstractLoggingEventInterceptor {
 
     public void handleMessage(Message message) throws Fault {
         createExchangeId(message);
-        final LogEvent event = logEventMapper.map(message);
+        final LogEvent event = logEventMapper.map(message, Collections.emptySet());
         if (shouldLogContent(event)) {
             addContent(message, event);
         } else {

--- a/frameworks/cxf/src/main/java/com/github/skjolber/xmlfilter/cxf/LoggingOutInterceptor.java
+++ b/frameworks/cxf/src/main/java/com/github/skjolber/xmlfilter/cxf/LoggingOutInterceptor.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Collections;
 
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.common.util.StringUtils;
@@ -67,7 +68,7 @@ public class LoggingOutInterceptor extends AbstractLoggingEventInterceptor {
                 }
             }
         } else {
-            final LogEvent event = logEventMapper.map(message);
+            final LogEvent event = logEventMapper.map(message, Collections.emptySet());
             event.setPayload(CONTENT_SUPPRESSED);
             logEventSender.send(event);
         }
@@ -130,7 +131,7 @@ public class LoggingOutInterceptor extends AbstractLoggingEventInterceptor {
         }
 
         public void close() throws IOException {
-            final LogEvent event = logEventMapper.map(message);
+            final LogEvent event = logEventMapper.map(message, Collections.emptySet());
             StringWriter w2 = out2;
             if (w2 == null) {
                 w2 = (StringWriter)out;
@@ -176,7 +177,7 @@ public class LoggingOutInterceptor extends AbstractLoggingEventInterceptor {
         }
 
         public void onClose(CachedOutputStream cos) {
-            final LogEvent event = logEventMapper.map(message);
+            final LogEvent event = logEventMapper.map(message, Collections.emptySet());
             copyPayload(cos, event);
 
             sender.send(event);

--- a/frameworks/cxf/src/test/java/com/github/skjolber/xmlfilter/cxf/RESTLoggingTest.java
+++ b/frameworks/cxf/src/test/java/com/github/skjolber/xmlfilter/cxf/RESTLoggingTest.java
@@ -161,8 +161,7 @@ public class RESTLoggingTest {
     }
     
     private void checkResponseOut(LogEvent responseOut) {
-        // Not yet available
-        assertNull(responseOut.getAddress());
+    	assertEquals(SERVICE_URI + "/test1", responseOut.getAddress());
         assertEquals("application/octet-stream", responseOut.getContentType());
         assertEquals(EventType.RESP_OUT, responseOut.getType());
         assertNull(responseOut.getEncoding());
@@ -175,8 +174,7 @@ public class RESTLoggingTest {
     }
     
     private void checkResponseIn(LogEvent responseIn) {
-        // Not yet available
-        assertNull(responseIn.getAddress());
+    	assertEquals(SERVICE_URI + "/test1", responseIn.getAddress());
         assertEquals("application/octet-stream", responseIn.getContentType());
         assertEquals(EventType.RESP_IN, responseIn.getType());
         assertEquals("ISO-8859-1", responseIn.getEncoding());

--- a/frameworks/cxf/src/test/java/com/github/skjolber/xmlfilter/cxf/SOAPLoggingTest.java
+++ b/frameworks/cxf/src/test/java/com/github/skjolber/xmlfilter/cxf/SOAPLoggingTest.java
@@ -110,8 +110,7 @@ public class SOAPLoggingTest {
     }
     
     private void checkResponseOut(LogEvent responseOut) {
-        // Not yet available
-        assertNull(responseOut.getAddress());
+    	assertEquals(SERVICE_URI, responseOut.getAddress());
         assertEquals("text/xml", responseOut.getContentType());
         assertEquals(EventType.RESP_OUT, responseOut.getType());
         assertEquals(StandardCharsets.UTF_8.name(), responseOut.getEncoding());
@@ -127,7 +126,7 @@ public class SOAPLoggingTest {
     }
     
     private void checkResponseIn(LogEvent responseIn) {
-        assertNull(responseIn.getAddress());
+    	assertEquals(SERVICE_URI, responseIn.getAddress());
         assertEquals("text/xml;charset=utf-8", responseIn.getContentType().toLowerCase().replace(" ", ""));
         assertEquals(EventType.RESP_IN, responseIn.getType());
         assertEquals(StandardCharsets.UTF_8.name(), responseIn.getEncoding());


### PR DESCRIPTION
Fix for #204 to support CXF version 3.4.x

The DefaultLogEventMapper "map" method is extended with a new parameter "sensitiveProtocolHeaders".
Like the CXF's DefaultLogEventMapperTest, this fix passes an empty set to the new parameter, to keep the old behavior. A null value gives a NullPointerException.

Already mentioned in the issue, but the new code is not compatible with CXF version 3.3.x

Furthermore some necessary changes to the unit tests where the comment "Not yet available" is apparently "yet available".